### PR TITLE
Fix ModuleList()[0] bug (pytorch 1.0)

### DIFF
--- a/NMT/src/model/transformer.py
+++ b/NMT/src/model/transformer.py
@@ -61,10 +61,10 @@ class TransformerEncoder(nn.Module):
             if layer_is_shared:
                 logger.info("Sharing encoder transformer parameters for layer %i" % k)
 
-            self.layers[k] = nn.ModuleList([
+            self.layers.append(nn.ModuleList([
                 # layer for first lang
                 TransformerEncoderLayer(args)
-            ])
+            ]))
             for i in range(1, self.n_langs):
                 # layer for lang i
                 if layer_is_shared:
@@ -167,10 +167,10 @@ class TransformerDecoder(nn.Module):
             if layer_is_shared:
                 logger.info("Sharing decoder transformer parameters for layer %i" % k)
 
-            self.layers[k] = nn.ModuleList([
+            self.layers.append(nn.ModuleList([
                 # layer for first lang
                 TransformerDecoderLayer(args)
-            ])
+            ]))
             for i in range(1, self.n_langs):
                 # layer for lang i
                 if layer_is_shared:

--- a/NMT/src/trainer.py
+++ b/NMT/src/trainer.py
@@ -466,7 +466,7 @@ class TrainerMT(MultiprocessingEventLoop):
 
         # encoded states
         encoded = self.encoder(sent1, len1, lang1_id)
-        self.stats['enc_norms_%s' % lang1].append(encoded.dis_input.data.norm(2, 1).mean())
+        self.stats['enc_norms_%s' % lang1].append(encoded.dis_input.data.norm(2, 1).mean().item())
 
         # cross-entropy scores / loss
         scores = self.decoder(encoded, sent2[:-1], lang2_id)


### PR DESCRIPTION
Doing `ModuleList()[0]` raises an error in pytorch 1.0, use append instead.

Also fix bug due to issue https://github.com/facebookresearch/UnsupervisedMT/issues/5